### PR TITLE
Replace has_git by test_requires_git

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -46,6 +46,7 @@ my $builder = $class->new(
 		'Test::Exception'              => 0,
 		'Test::FailWarnings'           => 0,
 		'Test::Git'                    => 0,
+		'Test::Requires::Git'          => 1.005,
 		'Test::More'                   => 0,
 		'Test::Type'                   => 0,
 	},

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -14,6 +14,7 @@ WriteMakefile
   'PREREQ_PM' => {
                    'Perl6::Slurp' => 0,
                    'Test::Git' => 0,
+                   'Test::Requires::Git' => 1.005,
                    'Test::Exception' => 0,
                    'Test::FailWarnings' => 0,
                    'Data::Dumper' => 0,

--- a/t/10-blame-ignore_whitespace.t
+++ b/t/10-blame-ignore_whitespace.t
@@ -11,12 +11,13 @@ use Test::Deep;
 use Test::Exception;
 use Test::FailWarnings -allow_deps => 1;
 use Test::Git;
+use Test::Requires::Git;
 use Test::More;
 use Test::Type;
 
 
 # Check there is a git binary available, or skip all.
-has_git( '1.5.0' );
+test_requires_git( '1.5.0' );
 
 # Declare the list of tests to run.
 my $tests =

--- a/t/10-blame.t
+++ b/t/10-blame.t
@@ -11,12 +11,13 @@ use Test::Deep;
 use Test::Exception;
 use Test::FailWarnings -allow_deps => 1;
 use Test::Git;
+use Test::Requires::Git;
 use Test::More;
 use Test::Type;
 
 
 # Check there is a git binary available, or skip all.
-has_git( '1.5.0' );
+test_requires_git( '1.5.0' );
 
 plan( tests => 16 );
 


### PR DESCRIPTION
Test::Git::has_git is obsolete and replaced by
Test::Requires::Git::test_requires_git.
